### PR TITLE
refactor!: use named export

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simple Linear Regression.
 ## Usage
 
 ```js
-import SimpleLinearRegression from 'ml-regression-simple-linear';
+import { SimpleLinearRegression } from 'ml-regression-simple-linear';
 
 const x = [0.5, 1, 1.5, 2, 2.5];
 const y = [0, 1, 2, 3, 4];

--- a/src/__tests__/test.test.ts
+++ b/src/__tests__/test.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from 'vitest';
 
-import SLR from '..';
+import { SimpleLinearRegression as SLR } from '..';
 
 describe('Simple Linear Regression', () => {
   it('SLR1', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ type JsonType = ReturnType<SimpleLinearRegression['toJSON']>;
  * Class representing simple linear regression.
  * The regression uses OLS to calculate intercept and slope.
  */
-export default class SimpleLinearRegression extends BaseRegression {
+export class SimpleLinearRegression extends BaseRegression {
   slope: number;
   intercept: number;
   coefficients: number[];


### PR DESCRIPTION
Seems to run fine, using:

```typescript
const { SimpleLinearRegression } = require("ml-regression-simple-linear");

const x = [1, 2, 3, 4, 5];
const y = [1, 3, 2, 3, 5];
const a = new SimpleLinearRegression(x, y);
console.log(a.toString());
```

```bash
lap@top:~/clones/test$ node test.js
f(x) = 0.8 * x + 0.3999999999999999
```
And using: 
```typescript
import { SimpleLinearRegression } from "ml-regression-simple-linear";
```

```bash
lap@top:~/clones/test$ node test.mjs 
f(x) = 0.8 * x + 0.3999999999999999
```

With Node versions:

```bash
node --version
v19.8.1
# and also
node --version
v18.16.0
```

Closes #11 