### PR TITLE
Demo

### DIFF
--- a/demo/example.tsx
+++ b/demo/example.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { PolynomialRegression } from 'ml-regression-polynomial';
+
+import { SimpleLinearRegression } from '../src/index';
+import {
+  Plot,
+  LineSeries,
+  Axis,
+  Legend,
+  Heading,
+  SeriesPoint,
+} from 'react-plot';
+
+const factor = 1;
+const data = [
+  { x: 0, y: 0 },
+  { x: 1, y: 1 },
+  { x: 2, y: 2 },
+  { x: 3, y: 3 },
+  { x: 4, y: 3 },
+  { x: 5, y: 3 },
+];
+
+const x = data.map((d) => d.x);
+const y = data.map((d) => d.y);
+
+const calculations: SeriesPoint[][] = [];
+
+for (let i = 0; i < 5; i++) {
+  if (i === 0) {
+    const r = new SimpleLinearRegression(x, y).predict(x);
+    const plot = r.map((y, i) => ({ x: x[i], y }));
+    calculations.push(plot);
+  } else {
+    const r = new PolynomialRegression(x, y, i, {
+      interceptAtZero: i % 2 === 1,
+    }).predict(x);
+    const plot = r.map((y, i) => ({ x: x[i], y }));
+    calculations.push(plot);
+  }
+}
+
+export const Example = () => (
+  <Plot
+    width={1000}
+    height={1000}
+    margin={{ bottom: 50, left: 90, top: 50, right: 100 }}
+  >
+    <Heading
+      title="Electrical characterization"
+      subtitle="Current vs Voltage"
+    />
+    <LineSeries
+      data={data}
+      xAxis="x"
+      yAxis="y"
+      lineStyle={{ strokeWidth: 3 }}
+      label="Raw Data"
+      displayMarkers={false}
+    />
+    {calculations.map((plot, i) => (
+      <LineSeries
+        key={i}
+        data={plot}
+        xAxis="x"
+        yAxis="y"
+        label={
+          i === 0
+            ? 'Simple Linear Regression'
+            : `Polynomial Regression (degree ${i})`
+        }
+      />
+    ))}
+    <Axis
+      id="x"
+      position="bottom"
+      label="Drain voltage [V]"
+      displayPrimaryGridLines
+      max={6.1 / factor}
+    />
+    <Axis
+      id="y"
+      position="left"
+      label="Drain current [mA]"
+      displayPrimaryGridLines
+      max={6.1 * factor}
+    />
+    <Legend position="right" />
+  </Plot>
+);

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { Example } from './example'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Example />
+  </React.StrictMode>,
+)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>1D Spectra</title>
+    <style>
+      * {
+        padding: 0.5rem;
+        margin: 0;
+        box-sizing: border-box;
+      }
+      body {
+        padding-top: 2rem;
+      }
+      label {
+        border-radius: 50% 25% 40% 10%;
+        border: 1.5px solid #ccc;
+        display: inline-block;
+        padding: 1rem;
+        margin: 1rem;
+      }
+      label:hover {
+        cursor: pointer;
+        background-color: bisque;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./demo/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -43,16 +43,16 @@
   "homepage": "https://github.com/mljs/regression-simple-linear#readme",
   "devDependencies": {
     "@vitejs/plugin-react": "^4.1.0",
-    "@vitest/coverage-v8": "^0.34.1",
-    "eslint": "^8.47.0",
+    "@vitest/coverage-v8": "^0.34.6",
+    "eslint": "^8.51.0",
     "eslint-config-cheminfo-typescript": "^12.0.4",
     "ml-regression-polynomial": "^3.0.0",
-    "prettier": "^3.0.1",
+    "prettier": "^3.0.3",
     "react-plot": "^1.4.2",
-    "rimraf": "^5.0.1",
-    "typescript": "^5.1.6",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11",
-    "vitest": "^0.34.1"
+    "vitest": "^0.34.6"
   },
   "dependencies": {
     "cheminfo-types": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test-only": "vitest --coverage --run",
     "tsc": "npm run clean && npm run tsc-cjs && npm run tsc-esm",
     "tsc-cjs": "tsc --project tsconfig.cjs.json",
-    "tsc-esm": "tsc --project tsconfig.esm.json"
+    "tsc-esm": "tsc --project tsconfig.esm.json",
+    "demo": "vite --open"
   },
   "repository": {
     "type": "git",
@@ -41,12 +42,16 @@
   },
   "homepage": "https://github.com/mljs/regression-simple-linear#readme",
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.1.0",
     "@vitest/coverage-v8": "^0.34.1",
     "eslint": "^8.47.0",
     "eslint-config-cheminfo-typescript": "^12.0.4",
+    "ml-regression-polynomial": "^3.0.0",
     "prettier": "^3.0.1",
+    "react-plot": "^1.4.2",
     "rimraf": "^5.0.1",
     "typescript": "^5.1.6",
+    "vite": "^4.4.11",
     "vitest": "^0.34.1"
   },
   "dependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,11 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.{test,spec}.ts'],
+    globals: true,
+  },
+  plugins: [react()],
+});


### PR DESCRIPTION
It seems that having a simple visual demo for:
* testing issues, 
* comparing regression results 
* maybe promoting `react-plot` 

Could be useful. This type of demo was added to some binary parsers as well.

For now it's limited (run with `npm run demo`):

![Screenshot at 2023-10-17 10-00-50](https://github.com/mljs/regression-simple-linear/assets/29411936/41d1919d-bba1-48fd-88fb-769d367aed88)

For example, comparing **green** and **blue** lines, we can see that  `polynomial-regression` with `interceptAtZero: true` does not fall over the linear version (but it does exactly using the default.)
